### PR TITLE
Update navigation links to point to the installation section and adju…

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         <nav class="hidden md:flex items-center space-x-1 bg-gray-100 rounded-lg p-1 border border-gray-200">
           <a href="#features" class="px-3 py-2 text-gray-600 hover:text-gray-900 hover:bg-white rounded-md transition-all duration-200 font-medium">Features</a>
           <a href="#about" class="px-3 py-2 text-gray-600 hover:text-gray-900 hover:bg-white rounded-md transition-all duration-200 font-medium">About</a>
-          <a href="https://github.com/archivelabs/lenny" class="ml-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md font-medium transition-all duration-200 shadow-sm hover:shadow-md">Try Lenny</a>
+          <a href="#installation" class="ml-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md font-medium transition-all duration-200 shadow-sm hover:shadow-md">Try Lenny</a>
         </nav>
 
         <!-- Mobile Menu Button -->
@@ -65,7 +65,7 @@
           <nav class="flex-1 px-6 py-6 space-y-4">
             <a href="#features" class="block px-4 py-3 text-gray-700 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all duration-200 font-medium">Features</a>
             <a href="#about" class="block px-4 py-3 text-gray-700 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all duration-200 font-medium">About</a>
-            <a href="https://github.com/archivelabs/lenny" class="block px-4 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-all duration-200 text-center mt-6">Try Lenny</a>
+            <a href="#installation" class="block px-4 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-all duration-200 text-center mt-6">Try Lenny</a>
           </nav>
         </div>
       </div>
@@ -85,7 +85,7 @@
           <div class="space-y-4">
             <h1 class="text-4xl lg:text-5xl xl:text-6xl font-bold leading-tight">
               Lenny:
-              <span class="text-blue-600">The Library-in-a-Box</span>
+              <span class="text-gray-900">The Library-in-a-Box</span>
             </h1>
             <p class="text-xl text-gray-600 leading-relaxed max-w-lg mx-auto lg:mx-0">
               Lenny is an plug-and-play, open-source, Library-in-a-Box that empowers libraries to preserve, own, and lend digital books on their own terms.
@@ -93,7 +93,7 @@
           </div>
           
           <div class="flex flex-col sm:flex-row gap-4 mt-6 justify-center lg:justify-start">
-            <a href="https://github.com/archivelabs/lenny" 
+            <a href="#installation" 
                class="group inline-flex items-center justify-center px-5 py-3 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-all duration-200 shadow-sm hover:shadow-md text-center">
               <svg class="w-4 h-4 mr-2 group-hover:translate-x-1 transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
@@ -128,7 +128,7 @@
   </section>
 
   <!-- Installation Section -->
-  <section class="py-20 bg-white">
+  <section id="installation" class="py-20 bg-white">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center space-y-8">
         <div class="space-y-4">
@@ -588,7 +588,7 @@
             
             <div class="hidden md:block w-px h-16 bg-gray-200"></div>
             
-            <a href="mailto:mek@archive.org" 
+            <a href="#installation" 
                class="inline-flex items-center px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-all duration-200 shadow-sm hover:shadow-md">
               Get Started
               <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
@mekarpeles 
This pull request updates the navigation and call-to-action links throughout the `index.html` landing page to improve user experience by directing users to the in-page "Installation" section instead of external or email links. It also updates the visual style of the main headline for consistency.

Navigation and Call-to-Action Link Updates:
* Changed all "Try Lenny" and "Get Started" links in navigation bars and hero sections to point to the `#installation` section within the page, rather than external URLs or mailto links. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L28-R28) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L68-R68) [[3]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L88-R96) [[4]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L591-R591)
* Added an `id="installation"` anchor to the installation section to enable in-page navigation.

Visual Updates:
* Changed the color of the "The Library-in-a-Box" headline from blue to gray for a more consistent look.