### PR TITLE
Change install command from 'sh' to 'bash'

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
             </div>
             <div class="bg-gray-900 rounded-lg p-6">
               <code class="text-green-400 font-mono text-sm md:text-base break-all block">
-                curl -fsSL https://raw.githubusercontent.com/ArchiveLabs/lenny/refs/heads/main/install.sh | sudo sh
+                curl -fsSL https://raw.githubusercontent.com/ArchiveLabs/lenny/refs/heads/main/install.sh | sudo bash
               </code>
             </div>
           </div>


### PR DESCRIPTION
This pull request makes a minor update to the installation instructions in the `index.html` file. The change replaces the use of `sh` with `bash` in the install command to ensure compatibility with shell features used in the script.

* Updated the install command to use `sudo bash` instead of `sudo sh` for running `install.sh` in the installation instructions in `index.html`.